### PR TITLE
Erase BuilderProposals flag

### DIFF
--- a/docs/operators/operator-node/node-setup/configuring-primev.md
+++ b/docs/operators/operator-node/node-setup/configuring-primev.md
@@ -14,8 +14,7 @@ To give you a short summary of the steps you'll need to take:
 1. [Install MEV Boost client](#install-mev-boost-client)
 2. [Choose preconf-compatible relays](#choose-compatible-relays)
 3. [Enable MEV in Beacon Client](#enable-mev-in-beacon-client)
-4. [Enable MEV in SSV](#enable-mev-in-ssv-node)
-5. [Register your validator(s) with PrimEV](#register-your-validator-with-primev)
+4. [Register your validator(s) with PrimEV](#register-your-validator-with-primev)
 
 ## Install MEV Boost client
 
@@ -39,13 +38,7 @@ Follow the setup guidelines for configuring MEV on your preferred client:
 
 ## Enable MEV in SSV node
 
-Builder proposals are managed by Beacon Client. You only need to make sure your SSV's `config.yaml` file has the following variable enabled. 
-```yaml
-ssv:
-  ValidatorOptions:
-    BuilderProposals: true 
-    # default value is true
-```
+Builder proposals are managed by Beacon Client. So once you've done the previous step, your SSV node will collaborate with MEV searchers.
 
 ## Register your validator with PrimEV
 

--- a/docs/operators/operator-node/node-setup/manual-setup.md
+++ b/docs/operators/operator-node/node-setup/manual-setup.md
@@ -160,10 +160,9 @@ ssv:
   Network: mainnet
   
   ValidatorOptions:
-    # default value is true
+    # Block proposals are by default controlled by Beacon Node.
     # Requires the connected Beacon node to be MEV-enabled.
     # Please see https://docs.ssv.network/operator-user-guides/operator-node/installation/configuring-mev
-    BuilderProposals: false
 
 eth2:
   # HTTP URL of the Beacon node to connect to.


### PR DESCRIPTION
This flag was disabled a while ago in https://github.com/ssvlabs/ssv/commit/a64d23defc20c8b068c84665dc125aede2bc8cd8

I removed all mentions of it and added comments that Proposals are managed by Beacon Node.