### PR TITLE
Hoodi support, Gas Limit, Primev name fixes

### DIFF
--- a/docs/operators/operator-node/README.md
+++ b/docs/operators/operator-node/README.md
@@ -11,7 +11,7 @@ To join the network as an operator a user must [install](./node-setup) the SSV n
 
 * [Installation Guide](./node-setup)
     * [Configuring MEV](/operators/operator-node/node-setup/configuring-mev)
-    * [Configuring Preconfirmations](./node-setup/configuring-primev.md)
+    * [Configuring Primev](./node-setup/configuring-primev.md)
     * [Enabling DKG](/operators/operator-node/node-setup/enabling-dkg/)
 * [Operator Registration](../operator-management/registration.md)
     * [Setting Operator Metadata](../operator-management/setting-operator-metadata.md)

--- a/docs/operators/operator-node/node-setup/README.md
+++ b/docs/operators/operator-node/node-setup/README.md
@@ -140,7 +140,7 @@ Edit the `ssv.env` file and adjust the settings to your needs. The minimum you n
 
 * `BEACON_NODE_ADDR` - HTTP address of the Beacon node (e.g. `http://1.2.3.4:5052`)
 * `ETH_1_ADDR` - WebSocket address of the Execution node (e.g. `ws://1.2.3.4:8546`)
-* `NETWORK` - The network you are running on (`mainnet`, `holesky`)
+* `NETWORK` - The network you are running on (`mainnet`, `holesky`, `hoodi`)
 :::info
 Both `BEACON_NODE_ADDR` and `ETH_1_ADDR` support multiple endpoints. Separate them with `;`.
 
@@ -162,6 +162,16 @@ We recommend using the default ports for ease of the setup.&#x20;
 If you wish to change any of the ports — change them in both `ssv.env` and `docker-compose.yaml`, then get [back to exposing those ports in your firewall];
 
 Changes to those files will be applied after a restart of the node (_if you already started your node_).
+
+### Hoodi specific
+**❗Do not use the following version on any network, except Hoodi**
+
+If you want to start your node with Hoodi network - you will need to use specific version of SSV. This can be set in your `docker-compose.yaml` file:
+```yaml
+  ssv-node:
+    image: docker.io/ssvlabs/ssv-node:v2.2.0-unstable.1
+```
+Also make sure you've set the correct network in your `.env` file to `NETWORK=hoodi`.
 
 ## Start the Node
 

--- a/docs/operators/operator-node/node-setup/configuring-primev.md
+++ b/docs/operators/operator-node/node-setup/configuring-primev.md
@@ -1,9 +1,9 @@
 ---
-title: Configuring PrimEV
+title: Configuring Primev
 sidebar_position: 5
 ---
 
-This guide outlines the necessary steps required to configure MEV-commit within your SSV node to enable operators to participate in MEV and preconfirmations. You can learn more about the concept and technical details on [PrimEV documentation](https://docs.primev.xyz/v1.0.0/get-started/welcome-to-primev). 
+This guide outlines the necessary steps required to configure MEV-commit within your SSV node to enable operators to participate in MEV and preconfirmations. You can learn more about the concept and technical details on [Primev documentation](https://docs.Primev.xyz/v1.0.0/get-started/welcome-to-Primev). 
 
 :::warning
 You should only participate if you're managing all operators in the cluster. If you will participate without one or many operators in the cluster — your MEV-commit collateral will be slashed. As an individual operator, you can always choose to [use regular MEV Boost](./configuring-mev.md).
@@ -14,7 +14,7 @@ To give you a short summary of the steps you'll need to take:
 1. [Install MEV Boost client](#install-mev-boost-client)
 2. [Choose preconf-compatible relays](#choose-compatible-relays)
 3. [Enable MEV in Beacon Client](#enable-mev-in-beacon-client)
-4. [Register your validator(s) with PrimEV](#register-your-validator-with-primev)
+4. [Register your validator(s) with Primev](#register-your-validator-with-Primev)
 
 ## Install MEV Boost client
 
@@ -22,7 +22,7 @@ The process is best described by the mev-boost team on [their GitHub page](https
 
 ## Choose compatible relays
 
-MEV-commit friendly relays are mentioned on [the PrimEV documentation](https://docs.primev.xyz/v1.0.0/get-started/validators/validator-guide#supporting-relays), you will find relays' URLs there too.
+MEV-commit friendly relays are mentioned on [the Primev documentation](https://docs.Primev.xyz/v1.0.0/get-started/validators/validator-guide#supporting-relays), you will find relays' URLs there too.
 
 ## Enable MEV in Beacon Client
 
@@ -40,7 +40,7 @@ Follow the setup guidelines for configuring MEV on your preferred client:
 
 Builder proposals are managed by Beacon Client. So once you've done the previous step, your SSV node will collaborate with MEV searchers.
 
-## Register your validator with PrimEV
+## Register your validator with Primev
 
 :::info
 Without completion of this step you will be practically using MEV Boost without any additional rewards.
@@ -50,7 +50,7 @@ The registry accepts validator's public key as the validator opt-in identifier. 
 
 The `VanillaRegistry.minStake` parameter represents how much ETH must be staked per validator pubkey to define that validator as opted-in to mev-commit. On Mainnet, `minStake` is 1 ETH, while on Holesky it’s 0.0001 ETH.
 
-- To learn more about this process, feel free to check out [PrimEV's explanation here](https://docs.primev.xyz/v1.0.0/get-started/validators/vanilla).
+- To learn more about this process, feel free to check out [Primev's explanation here](https://docs.Primev.xyz/v1.0.0/get-started/validators/vanilla).
 - To start the registration process, you can use [Mainnet](https://validators.mev-commit.xyz/) and [Holesky](https://holesky.validators.mev-commit.xyz/dashboard) validator dashboards. 
 You will need to submit your validators' pubkeys in a `.txt` file, each key on new line or separated by `,`.
 

--- a/docs/operators/operator-node/node-setup/gas-limit.md
+++ b/docs/operators/operator-node/node-setup/gas-limit.md
@@ -1,0 +1,40 @@
+---
+title: Gas Limit
+unlisted: true
+---
+
+# Gas Limit Change
+
+Recently, Ethereum community suggested an increase in Gas Limit to 36M (see https://pumpthegas.org). 
+
+The default gas limit is 30M and recent SSV release makes it configurable as long as the operator committees converge on the same value.
+
+:::danger Attention
+All operators in the committee **MUST** set the same gas limit, otherwise MEV registrations would fail and the validators would eventually not propose MEV blocks and instead fall back to local non-MEV blocks.
+
+**Do this only on private operators, and on clusters where you either can control all the operators, or coordinate with them**.
+:::
+
+## Configuration
+
+The SSV node registers its validators to MEV relays with a preferred gas limit. Starting from SSV version `v2.1.1` this gas limit becomes configurable:
+
+- For `.env` use `EXPERIMENTAL_GAS_LIMIT` variable
+- For `.yaml` configuration file use the following
+```yaml
+ValidatorOptions:
+    ExperimentalGasLimit: 36000000
+```
+
+Gas limit for local blocks (non-MEV) are set by the Execution Node  which you should ideally be set to the same value.
+
+
+## Verification 
+
+You can verify the configuration change works by querying one of the MEV relays used by the operator:
+
+```
+https://<relay-url>/relay/v1/data/validator_registration?pubkey=0x<validator-pubkey>
+```
+
+Validators are registered in a round-robin fashion once an hour, so you may have to wait this long or check more validators.

--- a/docs/operators/operator-node/node-setup/manual-setup.md
+++ b/docs/operators/operator-node/node-setup/manual-setup.md
@@ -156,7 +156,8 @@ db:
 ssv:
   # The SSV network to join to
   # Mainnet = Network: mainnet (default)
-  # Testnet = Network: holesky
+  # Holesky = Network: holesky
+  # Hoodi = Network: hoodi
   Network: mainnet
   
   ValidatorOptions:


### PR DESCRIPTION
- Hoodi support
  - On operator-node/node-setup page
  - On operator-node/node-setup/manual-setup page
- Gas Limit
  - Page with description added with `unlisted: true`
- Primev name was fixed everywhere it was mentioned