### PR TITLE
Fix &#x3C, DKG clean up, Gas Limit clean up

### DIFF
--- a/docs/developers/SSV-SDK/examples/create-validator-keys.md
+++ b/docs/developers/SSV-SDK/examples/create-validator-keys.md
@@ -35,7 +35,7 @@ import type { Address } from 'abitype'
 import type { Hex } from 'viem'
 import { sha256, toBytes, toHex } from 'viem'
 
-const chainConfigs: Record&#x3C;keyof typeof chains, ChainConfig> = {
+const chainConfigs: Record<keyof typeof chains, ChainConfig> = {
   mainnet: mainnetChainConfig,
   holesky: holeskyChainConfig,
 }
@@ -115,7 +115,7 @@ export async function createValidatorKeys({
 
   const chainConfig = chainConfigs[chain]
 
-  for (let i = index; i &#x3C; count; i++) {
+  for (let i = index; i < count; i++) {
     const sk = bls.SecretKey.fromBytes(deriveEth2ValidatorKeys(masterSK, i).signing)
     const pubkey = sk.toPublicKey()
     const pubkeyBytes = pubkey.toBytes()

--- a/docs/developers/tools/ssv-dkg-client/commands-and-config.md
+++ b/docs/developers/tools/ssv-dkg-client/commands-and-config.md
@@ -170,10 +170,10 @@ Alternatively, the tool can be launched providing the appropriate values to each
 
 ```bash
 docker run --rm -v ${pwd}:/ssv-dkg/data/ -it "ssvlabs/ssv-dkg:latest" init \
-    --owner &#x3C;OWNER_ADDRESS> \
-    --nonce &#x3C;OWNER_NONCE> \
-<strong>    --withdrawAddress &#x3C;WITHDRAWAL_ADDRESS> \
-</strong>    --operatorIDs &#x3C;OPERATOR_IDS_LIST> \
+    --owner <OWNER_ADDRESS> \
+    --nonce <OWNER_NONCE> \
+    --withdrawAddress <WITHDRAWAL_ADDRESS> \
+    --operatorIDs <OPERATOR_IDS_LIST> \
     --operatorsInfo "[{\"id\":121,\"public_key\":\"LS0tLS1CRUdJTiBSU0Eg...}]" \
     --network holesky \
     --tlsInsecure \

--- a/docs/operators/operator-node/node-setup/enabling-dkg/prerequisites.md
+++ b/docs/operators/operator-node/node-setup/enabling-dkg/prerequisites.md
@@ -7,15 +7,6 @@ sidebar_position: 1
 
 ## Minimum requirements
 
-:::danger CPU requirements
-The tool has cryptopgrahic dependencies on certain CPU features:
-- CPU has to have `BMI2 and ADX/AVX2` support.
-- On MacOS devices you need to **disable** Rosetta.
-
-If the requirements are not met - staker won't be able to generate keys with your DKG node and will see this specific error:
-`failed to validate ceremony proof: invalid proof validator pubkey`.
-:::
-
 The minimum requirement is an AWS `t3.small` or equivalent machine dedicated to run DKG.&#x20;
 The recommend requirement is an AWS `t3.medium` or higher tier machine  ([https://aws.amazon.com/ec2/instance-types/](https://aws.amazon.com/ec2/instance-types/)).
 

--- a/docs/operators/operator-node/node-setup/enabling-dkg/start-dkg-node/bring-your-own-tls-certification.md
+++ b/docs/operators/operator-node/node-setup/enabling-dkg/start-dkg-node/bring-your-own-tls-certification.md
@@ -5,7 +5,9 @@ sidebar_position: 2
 
 # Bring Your Own TLS Certification
 
+:::info Note
 By default, the certificates will be generated automatically on the first start of DKG tool. **The following steps are not required for the correct setup**.
+:::
 
 However, if you want to generate the certificates yourself, you can follow the steps below.
 

--- a/docs/operators/operator-node/node-setup/gas-limit.md
+++ b/docs/operators/operator-node/node-setup/gas-limit.md
@@ -5,12 +5,10 @@ unlisted: true
 
 # Gas Limit Change
 
-Recently, Ethereum community suggested an increase in Gas Limit to 36M (see https://pumpthegas.org). 
-
-The default gas limit is 30M and recent SSV release makes it configurable as long as the operator committees converge on the same value.
+The default gas limit is 30M and SSV makes it configurable as long as the operator committees converge on the same value.
 
 :::danger Attention
-All operators in the committee **MUST** set the same gas limit, otherwise MEV registrations would fail and the validators would eventually not propose MEV blocks and instead fall back to local non-MEV blocks.
+All operators in the committee **MUST** set the same gas limit. Otherwise, MEV registrations would fail. The validators would eventually not propose MEV blocks and instead fall back to vanilla blocks (non-MEV blocks built locally).
 
 **Do this only on private operators, and on clusters where you either can control all the operators, or coordinate with them**.
 :::
@@ -26,7 +24,7 @@ ValidatorOptions:
     ExperimentalGasLimit: 36000000
 ```
 
-Gas limit for local blocks (non-MEV) are set by the Execution Node  which you should ideally be set to the same value.
+Gas limit for vanilla blocks (non-MEV blocks built locally) are set by the Execution Node  which you should ideally be set to the same value.
 
 
 ## Verification 


### PR DESCRIPTION
- Fix &#x3C
  - /developers/tools/ssv-dkg-client/commands-and-config
  - /developers/SSV-SDK/examples/create-validator-keys/
- DKG pages cleanup
  - Removed CPU requirement /operators/operator-node/node-setup/enabling-dkg/prerequisites.md
  - Made a note more visible /operators/operator-node/node-setup/enabling-dkg/start-dkg-node/bring-your-own-tls-certification.md
- Gas Limit page cleanup
  - Removed historical references
  - Changed phrasing around vanilla blocks vs non-MEV blocks