### PR TITLE
Better section overviews, small rearrangements

### DIFF
--- a/docs/operators/README.md
+++ b/docs/operators/README.md
@@ -6,3 +6,8 @@ sidebar_position: 1
 # Operators
 
 Operators provide hardware infrastructure, run the SSV protocol, and are responsible for maintaining the overall health of ssv.network. Operators determine their own fees and are compensated for their integral services to the network by operating and maintaining validators on-behalf of stakers.
+
+**Short overview of this section:**
+1. [**Operator Onboarding**](./operator-onboarding/) - understand what operator is, what are the fees, and so on.
+2. [**Running a Node**](./operator-node/) - setup, run, and maintain your SSV Node.
+3. [**Operator Management**](./operator-management/) - register as operator in the network, managing fees, etc.

--- a/docs/operators/operator-management/README.md
+++ b/docs/operators/operator-management/README.md
@@ -5,3 +5,12 @@ sidebar_position: 8
 
 # Operator Management
 
+Once your SSV Node is up and running, you can register your Operator in the network and start earning rewards 🥳
+
+Overview of this section:
+* [**Operator Registration**](../operator-management/registration.md) - start participating in SSV Network.
+    * [Set Operator Metadata](../operator-management/setting-operator-metadata.md) - stakers will see this information on Explorer page.
+    * [*Updating Operator Fees*](../operator-management/updating-operator-fees.md) - (*optional*) in case you'd like to change your fees.
+    * [*Configuring a Permissioned Operator*](../operator-management/configuring-a-permissioned-operator.md) - (*optional*) in case you want to whitelist specific validator owners.
+* [Withdraw Earnings](../operator-management/withdrawing-earnings.md) - to receive your fees.
+* [Remove an Operator](../operator-management/removing-an-operator.md) - if you wish to stop participating.

--- a/docs/operators/operator-management/setting-operator-metadata.md
+++ b/docs/operators/operator-management/setting-operator-metadata.md
@@ -1,6 +1,6 @@
 ---
 title: Setting Operator metadata
-sidebar_position: 5
+sidebar_position: 2
 ---
 
 ### Connect your Web3 wallet to WebApp.

--- a/docs/operators/operator-management/updating-operator-fees.md
+++ b/docs/operators/operator-management/updating-operator-fees.md
@@ -1,6 +1,6 @@
 ---
 title: Updating Operator fees
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 ### Connect your Web3 wallet to WebApp

--- a/docs/operators/operator-management/withdrawing-earnings.md
+++ b/docs/operators/operator-management/withdrawing-earnings.md
@@ -1,6 +1,6 @@
 ---
 title: Withdrawing earnings
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 ### Connect your Web3 wallet to WebApp.

--- a/docs/operators/operator-node/README.md
+++ b/docs/operators/operator-node/README.md
@@ -5,17 +5,24 @@ sidebar_position: 7
 
 # Running a Node
 
-Operators provide hardware infrastructure, run the SSV protocol, and are responsible for maintaining the overall health of the SSV network. Operators determine their own fees and are compensated for their integral services to the network by operating and maintaining validators on-behalf of stakers.
+This section is to help you install and run your SSV Node 🚀
 
-To join the network as an operator a user must [install](./node-setup) the SSV node software, and [register](../operator-management/registration.md) the operator to the network.
+The steps to follow on your journey:
+1. [**Install SSV Node**](./node-setup)
+    * [Hardware Requirements](./node-setup/hardware-requirements.md) - to make sure your hardware is sufficient.
+    * [*Node Configuration Reference*](./node-setup/node-configuration-reference.md) - (*optional*) reference of SSV's node config.
+    * [*Manual Node Setup*](./node-setup/manual-setup.md) - (*optional*) alternative setup guide with manual installation.
+2. [**Install Sidecars**](/operators/operator-node/node-setup/enabling-dkg/)
+    * [Enable DKG](/operators/operator-node/node-setup/enabling-dkg/) - to participate in DKG ceremonies and get more validators.
+    * [Configure MEV](/operators/operator-node/node-setup/configuring-mev) - to increase rewards for block proposals.
+    * [Configure Primev](./node-setup/configuring-primev.md) - alternative to MEV, includes Pre-confirmations.
+3. [**Monitoring setup**](./monitoring/README.md)
+    * [Dashboard Runbook](./monitoring/dashboard-runbook.md) - install our Grafana dashboard and learn how to use it.
+    * [*Metrics Index*](./monitoring/metrics-index.md) - (*optional*) learn about SSV metrics in detail.
+4. [**Maintenance**](./maintenance/README.md)
+    * [Troubleshooting](./maintenance/troubleshooting.md) - identify and fix issues with your setup.
+    * [Common Errors](./maintenance/common-errors.md) - learn about most common errors you might see in your logs.
+    * [*Node Migration*](./maintenance/node-migration.md) - (*optional*) guide on how to migrate an SSV Node.
+    * [*DKG Node Migration*](./maintenance/dkg-operator-migration.md) - (*optional*) guide on how to migrate DKG Node.
 
-* [Installation Guide](./node-setup)
-    * [Configuring MEV](/operators/operator-node/node-setup/configuring-mev)
-    * [Configuring Primev](./node-setup/configuring-primev.md)
-    * [Enabling DKG](/operators/operator-node/node-setup/enabling-dkg/)
-* [Operator Registration](../operator-management/registration.md)
-    * [Setting Operator Metadata](../operator-management/setting-operator-metadata.md)
-    * [Updating Operator Fees](../operator-management/updating-operator-fees.md)
-* [Configuring a Permissioned Operator](../operator-management/configuring-a-permissioned-operator.md)
-* [Withdrawing Earnings](../operator-management/withdrawing-earnings.md)
-* [Removing an Operator](../operator-management/removing-an-operator.md)
+After you're done with installation, you can go and [register your operator](../operator-management/README.md) to the network.

--- a/docs/operators/operator-node/monitoring/dashboard-runbook.md
+++ b/docs/operators/operator-node/monitoring/dashboard-runbook.md
@@ -1,6 +1,6 @@
 ---
 title: Dashboard Runbook
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 import Link from '@docusaurus/Link';

--- a/docs/operators/operator-node/monitoring/metrics-index.md
+++ b/docs/operators/operator-node/monitoring/metrics-index.md
@@ -1,6 +1,6 @@
 ---
 title: Metrics Index
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 This document outlines the metrics instrumented in the SSV node (upstream dependencies not included), including their types, descriptions, and labels. They can help you build your own dashboards.

--- a/docs/operators/operator-node/node-setup/README.md
+++ b/docs/operators/operator-node/node-setup/README.md
@@ -168,16 +168,6 @@ If you wish to change any of the ports — change them in both `ssv.env` and `do
 
 Changes to those files will be applied after a restart of the node (_if you already started your node_).
 
-### Hoodi specific
-**❗Do not use the following version on any network, except Hoodi**
-
-If you want to start your node with Hoodi network - you will need to use specific version of SSV. This can be set in your `docker-compose.yaml` file:
-```yaml
-  ssv-node:
-    image: docker.io/ssvlabs/ssv-node:v2.2.0-unstable.1
-```
-Also make sure you've set the correct network in your `.env` file to `NETWORK=hoodi`.
-
 ## Start the Node
 
 To start your node use the following command


### PR DESCRIPTION
- Deleted `hoodi` specific section from Node Installation
- Rearranged pages slightly
- Added/edited overview of sections:
  - Running a Node
  - Operator Management
  - Operator main page