### PR TITLE
Database backup warnings + liquidator bot warning

### DIFF
--- a/docs/operators/liquidator-bot/installation.md
+++ b/docs/operators/liquidator-bot/installation.md
@@ -7,9 +7,13 @@ import TabItem from '@theme/TabItem';
 
 # Installation
 
+:::warning Hoodi is not supported
+Please note that SSV Mainnet has enough liquidators at the moment, so the tool is not actively updated. There is no official Hoodi support for `ssv-liquidator` tool.
+:::
+
 ### Prerequisites
 
-* [x] Wallet funded with sufficient ETH for transaction gas fees on the chosen network (Mainnet or Hoodi)
+* [x] Wallet funded with sufficient ETH for transaction gas fees on the chosen network (Mainnet or Holesky)
 * [x] Execution layer node end-point
 * [x] Reliable internet connection
 
@@ -40,7 +44,7 @@ This installation requires NodeJS on your machine.
   <TabItem value="cli" label="Option 1: Using CLI Arguments">
 
 ```sh
-yarn cli --ssv-sync-env=<prod | stage> --ssv-sync=<v4.hoodi | v4.mainnet | v4.prater> --node-url=<NODE_URL>  --private-key=<PRIVATE_KEY>  --gas-price=slow --max-visible-blocks=<MAX_BLOCKS>
+yarn cli --ssv-sync-env=<prod | stage> --ssv-sync=<v4.holesky | v4.mainnet | v4.prater> --node-url=<NODE_URL>  --private-key=<PRIVATE_KEY>  --gas-price=slow --max-visible-blocks=<MAX_BLOCKS>
 ```
 
   </TabItem>
@@ -55,7 +59,7 @@ GAS_PRICE=medium  # low | medium | high
 HIDE_TABLE=false
 MAX_VISIBLE_BLOCKS=50000
 SSV_SYNC_ENV=prod # prod or stage, prod - is default value
-SSV_SYNC=v4.prater # v4.hoodi | v4.mainnet | v4.prater
+SSV_SYNC=v4.prater # v4.holesky | v4.mainnet | v4.prater
 ```
 
   </TabItem>
@@ -64,17 +68,17 @@ SSV_SYNC=v4.prater # v4.hoodi | v4.mainnet | v4.prater
 :::warning
 Make sure that `--ssv-sync` and `--node-url` parameters (or `SSV_SYNC` and `NODE_URL` environment variables) are all relative to the same blockchain.
 
-For example, for hoodi (using a sample QuickNode RPC endpoint), the command should look like this:
+For example, for Holesky (using a sample QuickNode RPC endpoint), the command should look like this:
 
 ```sh
 yarn cli \
 --ssv-sync-env=prod \
---ssv-sync=v4.hoodi \
---node-url=https://red-silent-dawn.ethereum-hoodi.quiknode.pro/<ACCOUNT_ID>/  \
+--ssv-sync=v4.holesky \
+--node-url=https://red-silent-dawn.ethereum-holesky.quiknode.pro/<ACCOUNT_ID>/  \
 --private-key=<PRIVATE_KEY>  \
 --gas-price=slow    \
 --max-visible-blocks=5000
 ```
 
-The smart contract addresses were taken [from this page](../../developers/smart-contracts/#hoodi-testnet), in this instance.
+The smart contract addresses were taken [from this page](../../developers/smart-contracts/#holesky-testnet), in this instance.
 :::

--- a/docs/operators/operator-node/node-setup/README.md
+++ b/docs/operators/operator-node/node-setup/README.md
@@ -203,6 +203,11 @@ The same setup can be recreated manually. The steps are described on the [Manual
 
 Alternatively, SSV Node setup is also available using [eth-docker](https://eth-docker.net/Support/SSV/) and [Stereum Launcher](https://stereum.net/).
 
+## Database backups
+SSV's database (folder named `db`) is critical to prevent slashing. Its loss or corruption can lead to double-signing and severe penalties if operation continues.
+
+Be sure to implement a robust backup and recovery strategy for your database(s), it is **crucial** for operators. Failure to maintain database backups can lead to significant financial loss. Operators are responsible for their own database management and protection.
+
 ## What's next?
 
 * You might want to [configure MEV](/operators/operator-node/setup-sidecars/configuring-mev) to increase your rewards for block proposals.&#x20;

--- a/docs/operators/operator-node/node-setup/best-practices.md
+++ b/docs/operators/operator-node/node-setup/best-practices.md
@@ -68,6 +68,11 @@ EnableDoppelgangerProtection: true # Enables Doppelganger Protection
 - If you manage all nodes in the cluster — it is recommended to restart one by one. Otherwise, it will take 3 epochs to do the DG checks.
 - To learn more technical details please refer to [our documentation page on GitHub](https://github.com/ssvlabs/ssv/blob/v2.3.0/doppelganger/README.md).
 
+#### Database backups
+SSV's database is critical to prevent slashing (PostgreSQL for Web3Signer, or the node's local database `db` for local signing setups). Its loss or corruption can lead to double-signing and severe penalties if operation continues.
+
+Be sure to implement a robust backup and recovery strategy for your database(s), it is **crucial** for operators. Failure to maintain database backups can lead to significant financial loss. Operators are responsible for their own database management and protection.
+
 
 ## **Major impact**
 High‑priority practices that ensure reliable, on‑time duty submissions. Might sound obvious, but are often overlooked.

--- a/docs/operators/operator-node/node-setup/manual-setup.md
+++ b/docs/operators/operator-node/node-setup/manual-setup.md
@@ -324,3 +324,8 @@ p2p:
   UdpPort: 12001
   TcpPort: 13001
 ```
+
+### Database backups
+SSV's database (folder named `db`) is critical to prevent slashing. Its loss or corruption can lead to double-signing and severe penalties if operation continues.
+
+Be sure to implement a robust backup and recovery strategy for your database(s), it is **crucial** for operators. Failure to maintain database backups can lead to significant financial loss. Operators are responsible for their own database management and protection.

--- a/docs/operators/operator-node/setup-sidecars/remote-signer.md
+++ b/docs/operators/operator-node/setup-sidecars/remote-signer.md
@@ -438,6 +438,10 @@ database, cleaning keys in Web3Signer is required to ensure all shares are prope
 
 ## Security Considerations
 
+:::warning Slashing database backups
+SSV's database is critical to prevent slashing. Its loss or corruption can lead to double-signing and severe penalties if operation continues. It is **crucial** for operators to implement a robust backup and recovery strategy for their databases (PostgreSQL for Web3Signer, or the node's local database for local signing setups). Failure to maintain database backups can lead to significant financial loss. Operators are responsible for their own database management and protection.
+:::
+
 1. **Network Security**: Ensure communication between all components occurs over secure networks.
 2. **Key Protection**: Store operator keys securely restricting access to them.
 3. **Access Control**: Limit access to the SSV-Signer and Web3Signer endpoints to only the necessary services/IP addresses.


### PR DESCRIPTION
- Added warnings for operators to backup their `db` as per https://github.com/ssvlabs/ssv/pull/2285
  - On default SSV Node Setup page
  - On manual SSV Node Setup page
  - On Best Practices page
  - On SSV Signer doc page (still hidden)
- Mentioned Hoodi is not supported for Liquidator Bot