### PR TITLE
SSV Staking Mainnet readiness

### DIFF
--- a/docs/developers/SSV-SDK/README.md
+++ b/docs/developers/SSV-SDK/README.md
@@ -27,13 +27,6 @@ To install the SDK, run:
 npm i @ssv-labs/ssv-sdk
 ```
 
-:::info ⚠️ Testnet Version ⚠️
-The latest Hoodi-compatible version was not released to npm. To install it, download it from [the GitHub release](https://github.com/ssvlabs/ssv-sdk/releases/tag/v.1.0.0) or use the command below:
-```bash
-npm i --force --ignore-scripts github:ssvlabs/ssv-sdk#v.1.0.0
-```
-:::
-
 ## Initialization
 
 The SDK requires a `publicClient` configured with a supported chain (`mainnet` or `hoodi`). A `walletClient` is optional and is only needed for write operations. You can use [`viem`](https://www.npmjs.com/package/viem) to create both clients, whether you want a read-only setup or a read/write setup.

--- a/docs/developers/smart-contracts/README.md
+++ b/docs/developers/smart-contracts/README.md
@@ -20,6 +20,7 @@ sidebar_position: 5
 | Contract                  | Address                                                                                              |  ENS Name   |
 |---------------------------|------------------------------------------------------------------------------------------------------|-----------|
 | SSV Token                 | [0x9D65fF81a3c488d585bBfb0Bfe3c7707c7917f54](https://etherscan.io/address/0x9D65fF81a3c488d585bBfb0Bfe3c7707c7917f54) | ssv.ssvnetwork.eth |
+| cSSV Token                 | [0xe018D31F120A637828F46aFD6c64EC099d960546](https://etherscan.io/address/0xe018D31F120A637828F46aFD6c64EC099d960546) | cssv.ssvnetwork.eth |
 | SSV Network                | [0xDD9BC35aE942eF0cFa76930954a156B3fF30a4E1](https://etherscan.io/address/0xDD9BC35aE942eF0cFa76930954a156B3fF30a4E1) | ssvnetwork.eth |
 | SSV Network Views           | [0xafE830B6Ee262ba11cce5F32fDCd760FFE6a66e4](https://etherscan.io/address/0xafE830B6Ee262ba11cce5F32fDCd760FFE6a66e4) | views.ssvnetwork.eth |
 | Mainnet Rewards Distributor | [0xe16d6138b1d2ad4fd6603acdb329ad1a6cd26d9f](https://etherscan.io/address/0xe16d6138b1d2ad4fd6603acdb329ad1a6cd26d9f) | v1-imp.ssvnetwork.eth |
@@ -40,7 +41,7 @@ sidebar_position: 5
 
 #### ABI
 
-* [Mainnet](https://github.com/ssvlabs/ssv-network/tree/contract-abi/docs/mainnet/v1.2.0/abi)
+* [Mainnet](https://github.com/ssvlabs/ssv-network/tree/contract-abi/docs/mainnet/v2.0.0/abi)
 * [Testnet](https://github.com/ssvlabs/ssv-network/tree/contract-abi/docs/testnet/v2.0.0/abi)
 
 ### Ethereum Deposit Contract Addresses

--- a/docs/developers/smart-contracts/ssvnetwork.md
+++ b/docs/developers/smart-contracts/ssvnetwork.md
@@ -557,7 +557,7 @@ Events:
 
 ---
 
-#### **`setQuorumBps(quorum)`**
+#### **`updateQuorumBps(quorum)`**
 
 Description: DAO function to set the percentage of Oracles voting on the same Merkle root, in order for this to be accepted.
 
@@ -570,8 +570,20 @@ Events:
 
 ---
 
-#### **`setUnstakeCooldownDuration(duration)`**
+#### **`updateMinBlocksBetweenUpdates(blocks)`**
 
+Description: DAO function to set the minimum number of blocks between the updates of merkle root submitted by Oracles.
+
+| **Parameter** | **Type**  | **Description**               |
+| ------------- | --------- | ----------------------------- |
+| blocks         | uint32   | ???  |
+
+Events:
+* `MinBlocksBetweenUpdatesUpdated(uint32)`
+
+---
+
+#### **`updateUnstakeCooldownDuration(duration)`**
 Description: DAO function to set the time delay between the request of unstaking tokens and when such tokens can actually be withdrawn.
 
 | **Parameter** | **Type**  | **Description**               |

--- a/docs/developers/testnet.md
+++ b/docs/developers/testnet.md
@@ -20,7 +20,7 @@ https://app.ssv.network
 | SSV Network Views | [0x5AdDb3f1529C5ec70D77400499eE4bbF328368fe](https://hoodi.etherscan.io/address/0x5AdDb3f1529C5ec70D77400499eE4bbF328368fe) |
 
 
-### tSSV Faucet <a href="#id-652a6sxy0wse" id="id-652a6sxy0wse"></a>
+### tSSV Faucet
 
 The tSSV Faucet is a web interface that distributes small amounts of SSV tokens on Hoodi for validator registration on SSV Network and for testing.
 

--- a/docs/learn/security/audits.md
+++ b/docs/learn/security/audits.md
@@ -20,4 +20,4 @@ SSV Network has undergone multiple audits. You can find completed audit reports 
 | SSV Node - Peer-to-Peer protocol updates - "Alan" fork | October 2024 | [Link](https://github.com/ssvlabs/ssv/blob/main/audits/Hacken_SSV_Labs_L1_SSV_Labs_SSV_Node_Aug2024_P_2024_1212_2_20241016.pdf) | [Hacken](https://hacken.io/about/) |
 | SSV DKG - Reshare and Resign Features | November 2024 | [Link](https://github.com/ssvlabs/ssv-dkg/blob/main/audits/ChainSecurity%20Audit%20Report.pdf) | [ChainSecurity](https://www.chainsecurity.com/) |
 | SSV Node - SSV Signer | July 2025 | [Link](https://github.com/ssvlabs/ssv/blob/main/audits/SSV_SIGNER_FINAL_REPORT.pdf) | [Quantstamp](https://quantstamp.com/) |
-| Smart Contracts - SSV Staking and ETH Payments | March 2026 | [Link](https://github.com/ssvlabs/ssv-network/blob/mainnet-v2.0.0/contracts/audits/2026-03-24_Quantstamp_v1.2.0.pdf) | [Quantstamp](https://quantstamp.com/) |
+| Smart Contracts - SSV Staking and ETH Payments | March 2026 | [Link](https://github.com/ssvlabs/ssv-network/blob/ssv-staking/contracts/audits/2026-04-10_Quantstamp_v2.0.0.pdf) | [Quantstamp](https://quantstamp.com/) |


### PR DESCRIPTION
- Removed SDK warning about hoodi-only version
- cSSV smart contract address added
- Mainnet ABI link updated
- Updated audit to the latest one
- A couple of functions were renamed